### PR TITLE
Updated the evaluation metrics to be inline with OTEL standard schema

### DIFF
--- a/azure-ai-evaluation/metrics-azure-ai-evaluation-v0.1.0.json
+++ b/azure-ai-evaluation/metrics-azure-ai-evaluation-v0.1.0.json
@@ -10,7 +10,7 @@
                 "GenAI",
                 "Azure_AI_Evaluation"
             ],
-            "desiredDirection": "Decrease",
+            "desiredDirection": "Increase",
             "definition": {
                 "type": "Average",
                 "value": {

--- a/azure-ai-evaluation/metrics-azure-ai-evaluation-v0.1.0.json
+++ b/azure-ai-evaluation/metrics-azure-ai-evaluation-v0.1.0.json
@@ -15,8 +15,8 @@
                 "type": "Average",
                 "value": {
                     "eventName": "gen_ai.evaluation.result",
-                    "eventProperty": "gen_ai.evaluation.score",
-                    "filter": "['gen_ai.evaluator.name'] == 'TaskAdherence'"
+                    "eventProperty": "gen_ai.evaluation.score.value",
+                    "filter": "['gen_ai.evaluation.name'] == 'task_adherence'"
                 }
             }
         },
@@ -34,8 +34,8 @@
                 "type": "Average",
                 "value": {
                     "eventName": "gen_ai.evaluation.result",
-                    "eventProperty": "gen_ai.evaluation.score",
-                    "filter": "['gen_ai.evaluator.name'] == 'SelfHarm'"
+                    "eventProperty": "gen_ai.evaluation.score.value",
+                    "filter": "['gen_ai.evaluation.name'] == 'self_harm'"
                 }
             }
         },
@@ -53,8 +53,8 @@
                 "type": "Average",
                 "value": {
                     "eventName": "gen_ai.evaluation.result",
-                    "eventProperty": "gen_ai.evaluation.score",
-                    "filter": "['gen_ai.evaluator.name'] == 'HateUnfairness'"
+                    "eventProperty": "gen_ai.evaluation.score.value",
+                    "filter": "['gen_ai.evaluation.name'] == 'hate_unfairness'"
                 }
             }
         },
@@ -72,8 +72,8 @@
                 "type": "Average",
                 "value": {
                     "eventName": "gen_ai.evaluation.result",
-                    "eventProperty": "gen_ai.evaluation.score",
-                    "filter": "['gen_ai.evaluator.name'] == 'Sexual'"
+                    "eventProperty": "gen_ai.evaluation.score.value",
+                    "filter": "['gen_ai.evaluation.name'] == 'sexual'"
                 }
             }
         },
@@ -91,8 +91,8 @@
                 "type": "Average",
                 "value": {
                     "eventName": "gen_ai.evaluation.result",
-                    "eventProperty": "gen_ai.evaluation.score",
-                    "filter": "['gen_ai.evaluator.name'] == 'Violence'"
+                    "eventProperty": "gen_ai.evaluation.score.value",
+                    "filter": "['gen_ai.evaluation.name'] == 'violence'"
                 }
             }
         },
@@ -110,8 +110,8 @@
                 "type": "Average",
                 "value": {
                     "eventName": "gen_ai.evaluation.result",
-                    "eventProperty": "gen_ai.evaluation.score",
-                    "filter": "['gen_ai.evaluator.name'] == 'Relevance'"
+                    "eventProperty": "gen_ai.evaluation.score.value",
+                    "filter": "['gen_ai.evaluation.name'] == 'relevance'"
                 }
             }
         },
@@ -129,8 +129,8 @@
                 "type": "Average",
                 "value": {
                     "eventName": "gen_ai.evaluation.result",
-                    "eventProperty": "gen_ai.evaluation.score",
-                    "filter": "['gen_ai.evaluator.name'] == 'Fluency'"
+                    "eventProperty": "gen_ai.evaluation.score.value",
+                    "filter": "['gen_ai.evaluation.name'] == 'fluency'"
                 }
             }
         },
@@ -148,8 +148,8 @@
                 "type": "Average",
                 "value": {
                     "eventName": "gen_ai.evaluation.result",
-                    "eventProperty": "gen_ai.evaluation.score",
-                    "filter": "['gen_ai.evaluator.name'] == 'Retrieval'"
+                    "eventProperty": "gen_ai.evaluation.score.value",
+                    "filter": "['gen_ai.evaluation.name'] == 'coherence'"
                 }
             }
         },
@@ -157,7 +157,7 @@
             "id": "genai_evaluation_indirect_attack",
             "displayName": "Average indirect attack score",
             "description": "The average indirect attack score given by Azure AI evaluation. This evaluator analyzes a single-turn or multi-turn conversation to detect cross-domain prompt-injection attacks (also called indirect or XPIA jailbreaks) that are embedded in the supplied context. Indirect attacks are grouped into three subcategories: (1) Manipulated Content – commands that alter, fabricate, hide, or emphasize information to mislead or deceive; (2) Intrusion – commands that attempt to breach systems, gain unauthorized access, or escalate privileges (e.g., traditional jailbreaks, backdoors, vulnerability exploits); and (3) Information Gathering – actions that access, delete, or modify data without authorization, including data exfiltration and record tampering. The evaluator returns a boolean value where true indicates that the response contains an indirect attack. See https://learn.microsoft.com/en-us/python/api/azure-ai-evaluation/azure.ai.evaluation.indirectattackevaluator for details.",
-            "lifecycle": "Active",
+            "lifecycle": "Inactive",
             "categories": [
                 "GenAI",
                 "Azure_AI_Evaluation"
@@ -167,8 +167,8 @@
                 "type": "Average",
                 "value": {
                     "eventName": "gen_ai.evaluation.result",
-                    "eventProperty": "gen_ai.evaluation.score",
-                    "filter": "['gen_ai.evaluator.name'] == 'IndirectAttack'"
+                    "eventProperty": "gen_ai.evaluation.score.value",
+                    "filter": "['gen_ai.evaluation.name'] == 'IndirectAttack'"
                 }
             }
         },
@@ -186,8 +186,8 @@
                 "type": "Average",
                 "value": {
                     "eventName": "gen_ai.evaluation.result",
-                    "eventProperty": "gen_ai.evaluation.score",
-                    "filter": "['gen_ai.evaluator.name'] == 'CodeVulnerability'"
+                    "eventProperty": "gen_ai.evaluation.score.value",
+                    "filter": "['gen_ai.evaluation.name'] == 'code_vulnerability'"
                 }
             }
         },
@@ -205,8 +205,8 @@
                 "type": "Average",
                 "value": {
                     "eventName": "gen_ai.evaluation.result",
-                    "eventProperty": "gen_ai.evaluation.score",
-                    "filter": "['gen_ai.evaluator.name'] == 'IntentResolution'"
+                    "eventProperty": "gen_ai.evaluation.score.value",
+                    "filter": "['gen_ai.evaluation.name'] == 'intent_resolution'"
                 }
             }
         },
@@ -224,8 +224,8 @@
                 "type": "Average",
                 "value": {
                     "eventName": "gen_ai.evaluation.result",
-                    "eventProperty": "gen_ai.evaluation.score",
-                    "filter": "['gen_ai.evaluator.name'] == 'ToolCallAccuracy'"
+                    "eventProperty": "gen_ai.evaluation.score.value",
+                    "filter": "['gen_ai.evaluation.name'] == 'tool_call_accuracy'"
                 }
             }
         }


### PR DESCRIPTION
## Purpose
Update the evaluation metrics to adhere to the latest OTEL schema as defined here: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/gen-ai.md#genai-attributes. There are 3 main changes:
1. Change of filter from gen_ai.evalutor.name to gen_ai.evaluation.name
2. Change of the evaluation name to adhere to schema defined here: https://github.com/Azure/azureml-assets/tree/fcd0456c6e2755f25fa3acbb897f0ca5e8dd6b28/assets/evaluators/builtin
3. Change gen_ai.evaluation.score to gen_ai.evaluation.score.value

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[X] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: Change to genai evaluations metric definition
```